### PR TITLE
Adds recommendation by artist

### DIFF
--- a/src/components/DynamicRecommendations.tsx
+++ b/src/components/DynamicRecommendations.tsx
@@ -8,7 +8,7 @@ class DynamicRecommendations extends React.Component<{}, {songQueue: Array<strin
   state = {
     songQueue: Spicetify.LocalStorage.get("songQueue")?.split(',') || new Array<string>,
     artistQueue: Spicetify.LocalStorage.get("artistQueue")?.split(',') || new Array<string>,
-    recTarget: "artists",
+    recTarget: "songs",
     recommendations: {},
   }
 
@@ -123,6 +123,19 @@ class DynamicRecommendations extends React.Component<{}, {songQueue: Array<strin
     });
   };
 
+  changeRecTarget = () => {
+    if (this.state.recTarget == "songs") {
+      this.setState({
+        recTarget: "artists",
+      }, () => this.generateRecommendations());
+    }
+    else if (this.state.recTarget == "artists") {
+      this.setState({
+        recTarget: "songs",
+      }, () => this.generateRecommendations());
+    }
+  };
+
   render() {
     Spicetify.Player.addEventListener("onprogress", this.addToQueue);
     return (
@@ -132,6 +145,9 @@ class DynamicRecommendations extends React.Component<{}, {songQueue: Array<strin
           {"artistQueue: " + String(this.state.artistQueue) + "\n"}
           {JSON.stringify(Object.keys(this.state.recommendations).length != 0 ? (this.state.recommendations as GetRecommendationsResponse)["tracks"][0].name : {})}
         </text>
+        <button onClick={this.changeRecTarget}>
+          {this.state.recTarget}
+        </button>
       </>
     );
   }

--- a/src/components/DynamicRecommendations.tsx
+++ b/src/components/DynamicRecommendations.tsx
@@ -74,22 +74,26 @@ class DynamicRecommendations extends React.Component<{}, {songQueue: Array<strin
     });
   };
 
-  setArtistQueue = () => {
+  shouldArtistQueueBeUpdated = (): boolean => {
     if (!Spicetify.Player.data.item.artists) {
-      return;
+      return false;
+    }
+    if (!this.state.artistQueue) {
+      return true;
     }
 
-    let cont = false;
-    if (this.state.artistQueue) {
-      for (const artist of Spicetify.Player.data.item.artists) {
-        let fromIndex = this.state.artistQueue.length >= Spicetify.Player.data.item.artists.length ? this.state.artistQueue.length - Spicetify.Player.data.item.artists.length : 0;
-        if (!this.state.artistQueue.includes(getID(artist.uri), fromIndex)) {
-          cont = true;
-          break;
-        };
-      }
+    for (const artist of Spicetify.Player.data.item.artists) {
+      let fromIndex = Math.max(0, this.state.artistQueue.length - Spicetify.Player.data.item.artists.length);
+      if (!this.state.artistQueue.includes(getID(artist.uri), fromIndex)) {
+        return true;
+      };
     }
-    if (!cont) {
+
+    return false;
+  };
+
+  setArtistQueue = () => {
+    if (!Spicetify.Player.data.item.artists || !this.shouldArtistQueueBeUpdated()) {
       return;
     }
 

--- a/src/components/DynamicRecommendations.tsx
+++ b/src/components/DynamicRecommendations.tsx
@@ -4,9 +4,9 @@ import getRecommendations from "../services/dynamicRecommendationsService";
 import { GetRecommendationsInput, GetRecommendationsResponse } from "../types/spotify-web-api.d";
 import getID from './../services/common';
 
-class DynamicRecommendations extends React.Component<{}, {queue: Array<string>, artistQueue: Array<string>, recTarget: string, recommendations: GetRecommendationsResponse | {}}> {
+class DynamicRecommendations extends React.Component<{}, {songQueue: Array<string>, artistQueue: Array<string>, recTarget: string, recommendations: GetRecommendationsResponse | {}}> {
   state = {
-    queue: Spicetify.LocalStorage.get("queue")?.split(',') || new Array<string>,
+    songQueue: Spicetify.LocalStorage.get("songQueue")?.split(',') || new Array<string>,
     artistQueue: Spicetify.LocalStorage.get("artistQueue")?.split(',') || new Array<string>,
     recTarget: "artists",
     recommendations: {},
@@ -19,7 +19,7 @@ class DynamicRecommendations extends React.Component<{}, {queue: Array<string>, 
   generateRecommendations = async () => {
     let apiOptions = new GetRecommendationsInput();
     if (this.state.recTarget == "songs") {
-      apiOptions.data.seed_tracks = this.state.queue.toString();
+      apiOptions.data.seed_tracks = this.state.songQueue.toString();
     }
     else if (this.state.recTarget == "artists") {
       apiOptions.data.seed_artists = this.state.artistQueue.toString(); 
@@ -47,11 +47,11 @@ class DynamicRecommendations extends React.Component<{}, {queue: Array<string>, 
 
   setSongQueue = () => {
     let curSongID = getID(Spicetify.Player.data.item.uri);
-    if (this.state.queue && this.state.queue[this.state.queue.length-1] == curSongID) {
+    if (this.state.songQueue && this.state.songQueue[this.state.songQueue.length-1] == curSongID) {
       return;
     }
 
-    let newQueue = this.state.queue.slice();
+    let newQueue = this.state.songQueue.slice();
     if (newQueue.includes(curSongID)) {
       newQueue = newQueue.filter((val, ind) => val != curSongID);
     }
@@ -62,12 +62,12 @@ class DynamicRecommendations extends React.Component<{}, {queue: Array<string>, 
     }
 
     this.setState({
-      queue: newQueue,
+      songQueue: newQueue,
     }, () => {
-      if (Spicetify.LocalStorage.get("queue") == this.state.queue.toString()) {
+      if (Spicetify.LocalStorage.get("songQueue") == this.state.songQueue.toString()) {
         return;
       }
-      Spicetify.LocalStorage.set("queue", this.state.queue.toString());
+      Spicetify.LocalStorage.set("songQueue", this.state.songQueue.toString());
       if (this.state.recTarget == "songs") {
         this.generateRecommendations();
       }
@@ -124,7 +124,7 @@ class DynamicRecommendations extends React.Component<{}, {queue: Array<string>, 
     return (
       <>
         <text className={styles.text}>
-          {"songQueue: " + String(this.state.queue) + "\n"}
+          {"songQueue: " + String(this.state.songQueue) + "\n"}
           {"artistQueue: " + String(this.state.artistQueue) + "\n"}
           {JSON.stringify(Object.keys(this.state.recommendations).length != 0 ? (this.state.recommendations as GetRecommendationsResponse)["tracks"][0].name : {})}
         </text>

--- a/src/services/common.tsx
+++ b/src/services/common.tsx
@@ -1,0 +1,5 @@
+function getID(uri: string): string {
+  return uri.split(":")[2];
+}
+
+export default getID;

--- a/src/services/nowPlayingService.tsx
+++ b/src/services/nowPlayingService.tsx
@@ -1,4 +1,5 @@
 import type { AudioFeaturesResponse } from "../types/spotify-web-api";
+import getID from "./common";
 
 async function getAudioFeatures(songURI: string | undefined): Promise<AudioFeaturesResponse | {}> {
     if (!songURI) {
@@ -7,7 +8,7 @@ async function getAudioFeatures(songURI: string | undefined): Promise<AudioFeatu
 
     var accessToken = Spicetify.Platform.Session.accessToken;
 
-    var songID = songURI.split(":")[2];
+    var songID = getID(songURI);
     let response = await fetch(
         "https://api.spotify.com/v1/audio-features/" + songID,
         {


### PR DESCRIPTION
This PR adds dynamic recommendations by artists.

I also had to add logic for both the songs and artists to refresh a song's or artist's position in the queue if it is played again while it is still in the queue. This means for example if you play the same song again within the next 4 songs, it now actually gets refreshed to appear as a "new" song.

Similar logic was implemented for the artists, except it is more complicated since there are potentially multiple artists per song and the order that these artists appear in the `Spicetify.Player.data.item.artists` array can differ. So I basically checked if every artist appears within the last `Spicetify.Player.data.item.artists.length` positions of the queue, and if it doesn't that means you need to refresh the positions. I did this in a naive way, it's not at all optimized but our array size is so small I think it doesn't matter at all.

I also added a small button to allow changing between recommending by songs or artists.

Adding recommendations by genres is going to be more complicated because apparently Spotify doesn't have genres for each song(?). So, we have to get genres by artists. BUT, all genres are not allowed to be used to generate recommendations. We would have to first get all the available genres from the `/recommendations/available-genre-seeds` endpoint and then get all the genres attached to each artist and check if it falls in that list. If it does, then only can we add the genre to the queue. I am planning on implementing this in a future PR.