### PR TITLE
Cleanup and dynamically showing song metrics

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import NowPlaying from "./components/NowPlaying";
-import DynamicRecommendations from "./components/DynamicRecommendations";
 
 class App extends React.Component<{}, {}> {
   render() {
     return (
       <>
         <NowPlaying />
-        <DynamicRecommendations />
       </>
     );
   }

--- a/src/components/DynamicRecommendations.tsx
+++ b/src/components/DynamicRecommendations.tsx
@@ -154,12 +154,16 @@ class DynamicRecommendations extends React.Component<{recTargetProp : string}, {
           </div>
           <div className={styles.recommendationsBlock}>
             {function(recommendations : GetRecommendationsResponse | {}) {
+              if (Object.keys(recommendations).length == 0) {
+                return;
+              }
+              let recs = (recommendations as GetRecommendationsResponse)["tracks"];
               let recommendedTracksHTML = [];
               for (let i = 0; i < 6; i++) {
-                let recommendedSong = <RecommendedTrack songCover={Object.keys(recommendations).length > 0 ? (recommendations as GetRecommendationsResponse)["tracks"][i].album.images[0].url : ""}
-                                                        songAlbum={Object.keys(recommendations).length > 0 ? (recommendations as GetRecommendationsResponse)["tracks"][i].album.name : ""}
-                                                        songName={Object.keys(recommendations).length > 0 ? (recommendations as GetRecommendationsResponse)["tracks"][i].name : ""}
-                                                        songArtists={Object.keys(recommendations).length > 0 ? (recommendations as GetRecommendationsResponse)["tracks"][i].artists.map((artist) => artist.name):[]}
+                let recommendedSong = <RecommendedTrack songCover={recs[i].album.images[0].url}
+                                                        songAlbum={recs[i].album.name}
+                                                        songName={recs[i].name}
+                                                        songArtists={recs[i].artists.map((artist) => artist.name)}
                                                         key={i}>
                                       </RecommendedTrack>;
                 recommendedTracksHTML.push(recommendedSong);

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -151,27 +151,10 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
           {"Song Statistics"}
         </div>
         <div className={styles.statsBlock}>
+          {/* Stats block data */}
           {this.state.songMetrics.map((songMetric: SongMetricData, i) => {
             return <SongMetric title={songMetric.title} floatValue={songMetric.floatValue} label={songMetric.label} progressBar={songMetric.progressBar} />;
           })}
-
-          {/* Statistic #1 */}
-          {/* <SongMetric title="Danceability" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["danceability"]} label="" progressBar={true} /> */}
-
-          {/* Statistic #2 */}
-          {/* <SongMetric title="Energy" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["energy"]} label="" progressBar={true} /> */}
-
-          {/* Statistic #3 */}
-          {/* <SongMetric title="Acousticness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["acousticness"]} label="" progressBar={true} /> */}
-
-          {/* Statistic #4 */}
-          {/* <SongMetric title="Loudness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["loudness"]} label="dB" progressBar={false} /> */}
-
-          {/* Statistic #5 */}
-          {/* <SongMetric title="Key" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["key"]} label="" progressBar={false} /> */}
-
-          {/* Statistic #6 */}
-          {/* <SongMetric title="Tempo" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["tempo"]} label="" progressBar={false} /> */}
         </div>
         <div>
           <div className={styles.recommendationsLabel} style={{marginLeft: "20px",

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -17,8 +17,8 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
     audioFeatures: {},  // Features of the currently playing song (name, artist, stats)
     songURI: "",        // URI of the currently playing song
     recTarget: "songs", // Recommendations based on either songs or artist
-    songMetrics: [],
-    metricsToDisplay: [],
+    songMetrics: [], // Current song metric information
+    metricsToDisplay: [], // Current metric information types
   }
 
   componentDidMount = () => {
@@ -47,9 +47,10 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
     apiCall();
   }
 
+  // Sets the song metric information based on the type of information that the user wants to be displayed
   setSongMetrics = () => {
     this.setState({
-      metricsToDisplay: ["Danceability", "Energy", "Acousticness", "Loudness", "Key", "Tempo"]
+      metricsToDisplay: ["Danceability", "Energy", "Acousticness", "Loudness", "Key", "Tempo"] // TODO: Change so that we get the metrics we want to display dynamically
     }, () => {
       this.setState({
         songMetrics: getSongMetrics((this.state.audioFeatures as AudioFeaturesResponse), this.state.metricsToDisplay)

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -5,6 +5,7 @@ import { AudioFeaturesResponse } from "../types/spotify-web-api";
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import DynamicRecommendations from "./DynamicRecommendations";
+import SongMetric from "./SongMetric";
 
 class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesResponse | {}, 
                                               songURI: string, 
@@ -135,89 +136,22 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
         </div>
         <div className={styles.statsBlock}>
           {/* Statistic #1 */}
-          <div className={styles.statContainer}>
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Danceability"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {Math.round(parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["danceability"]) * 100)}
-              </div>
-            </div>
-            <div className={styles.graphicContainer}>
-              <CircularProgressbar styles={{path: {stroke: "white"}, trail: {stroke: "rgb(80,80,80)"}}} 
-                                   value={parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["danceability"])} maxValue={1}>
-              </CircularProgressbar>
-            </div>
-          </div>
+          <SongMetric title="Danceability" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["danceability"]} label="" progressBar={true} />
+
           {/* Statistic #2 */}
-          <div className={styles.statContainer}>
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Energy"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {Math.round(parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["energy"]) * 100)}
-              </div>
-            </div>
-            <div className={styles.graphicContainer}>
-              <CircularProgressbar styles={{path: {stroke: "white"}, trail: {stroke: "rgb(80,80,80)"}}} 
-                                   value={parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["energy"])} maxValue={1}>
-              </CircularProgressbar>
-            </div>
-          </div>
+          <SongMetric title="Energy" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["energy"]} label="" progressBar={true} />
+
           {/* Statistic #3 */}
-          <div className={styles.statContainer}>
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Acousticness"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {Math.round(parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["acousticness"]) * 100)}
-              </div>
-            </div>
-            <div className={styles.graphicContainer}>
-              <CircularProgressbar styles={{path: {stroke: "white"}, trail: {stroke: "rgb(80,80,80)"}}} 
-                                   value={parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["acousticness"])} maxValue={1}>
-              </CircularProgressbar>
-            </div>
-          </div>
+          <SongMetric title="Acousticness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["acousticness"]} label="" progressBar={true} />
+
           {/* Statistic #4 */}
-          <div className={styles.statContainer}> 
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Loudness"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {Math.round(parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["loudness"]))}
-                <span className={styles.text} style={{fontSize: "25px", color: "white", fontWeight: "550", marginLeft: "5px"}}>
-                  {"dB"}
-                </span>
-              </div>
-            </div>
-          </div>
+          <SongMetric title="Loudness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["loudness"]} label="dB" progressBar={false} />
+
           {/* Statistic #5 */}
-          <div className={styles.statContainer}>
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Key"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {(this.state.audioFeatures as AudioFeaturesResponse)["key"]}
-              </div>
-            </div>
-          </div>
+          <SongMetric title="Key" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["key"]} label="" progressBar={false} />
+
           {/* Statistic #6 */}
-          <div className={styles.statContainer}> 
-            <div className={styles.statTextContainer}>
-              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
-                {"Tempo"}
-              </div>
-              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
-                {Math.round(parseFloat((this.state.audioFeatures as AudioFeaturesResponse)["tempo"]))}
-              </div>
-            </div>
-          </div>
+          <SongMetric title="Tempo" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["tempo"]} label="" progressBar={false} />
         </div>
         <div>
           <div className={styles.recommendationsLabel} style={{marginLeft: "20px",

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -80,65 +80,67 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
       <> 
         <div className={styles.topBar}>
           <div className={styles.nowPlayingSidebar}>
-            <div className={styles.trackInfoPrimary}>
-              {/* Track cover */}
-              {Spicetify.Player.data.item.images ? 
-                Spicetify.Player.data.item.images.length > 0 ? 
-                  <img src={Spicetify.Player.data.item.images[0].url} className={styles.trackCover}/> 
-                : <></> 
-              : <></>}
+            {Spicetify.Player.data ? 
+              <div className={styles.trackInfoPrimary}>
+                {/* Track cover */}
+                {Spicetify.Player.data.item.images ? 
+                  Spicetify.Player.data.item.images.length > 0 ? 
+                    <img src={Spicetify.Player.data.item.images[0].url} className={styles.trackCover}/> 
+                  : <></> 
+                : <></>}
 
-              {/* Track title */}
-              <text className={styles.text} style={{marginTop: "5px", 
-                                                    fontSize: "30px",
-                                                    fontWeight: "530",
-                                                    textOverflow: "ellipsis",
-                                                    overflow: "hidden", 
-                                                    whiteSpace: "nowrap",
-                                                    textAlign: "center",
-                                                    alignContent: "center",
-                                                    width: "250px",
-                                                    color: "white"}}>
-                {Spicetify.Player.data.item.name}
-              </text>
+                {/* Track title */}
+                <text className={styles.text} style={{marginTop: "5px", 
+                                                      fontSize: "30px",
+                                                      fontWeight: "530",
+                                                      textOverflow: "ellipsis",
+                                                      overflow: "hidden", 
+                                                      whiteSpace: "nowrap",
+                                                      textAlign: "center",
+                                                      alignContent: "center",
+                                                      width: "250px",
+                                                      color: "white"}}>
+                  {Spicetify.Player.data.item.name}
+                </text>
 
-              {/* Track artist(s) */}
-              {(function () {
+                {/* Track artist(s) */}
+                {(function () {
 
-                // Get all the artists
-                const trackArtists = Spicetify.Player.data.item.artists;
-                let trackAritistsInnnerHTML = "";
+                  // Get all the artists
+                  const trackArtists = Spicetify.Player.data.item.artists;
+                  let trackAritistsInnnerHTML = "";
 
-                // Check if there are any artists
-                if (trackArtists) {
-                  // Display all the artists
-                  for (const artist of trackArtists) {
-                    trackAritistsInnnerHTML += (artist.name + ", ")
+                  // Check if there are any artists
+                  if (trackArtists) {
+                    // Display all the artists
+                    for (const artist of trackArtists) {
+                      trackAritistsInnnerHTML += (artist.name + ", ")
+                    }
+                    if(trackAritistsInnnerHTML.length > 0) {
+                      trackAritistsInnnerHTML = trackAritistsInnnerHTML.substring(0, trackAritistsInnnerHTML.length - 2);
+                    }
+
+                    return <text className={styles.text} style={{fontSize: "15px", 
+                                                                marginBottom: "2px",
+                                                                textOverflow: "ellipsis",
+                                                                width: "250px",
+                                                                textAlign: "center",}}> 
+                              {trackAritistsInnnerHTML} 
+                            </text>
+                  } else {
+                    return <></>;
                   }
-                  if(trackAritistsInnnerHTML.length > 0) {
-                    trackAritistsInnnerHTML = trackAritistsInnnerHTML.substring(0, trackAritistsInnnerHTML.length - 2);
-                  }
+                })()}
 
-                  return <text className={styles.text} style={{fontSize: "15px", 
-                                                              marginBottom: "2px",
-                                                              textOverflow: "ellipsis",
-                                                              width: "250px",
-                                                              textAlign: "center",}}> 
-                            {trackAritistsInnnerHTML} 
-                          </text>
-                } else {
-                  return <></>;
-                }
-              })()}
-
-              {/* Track album */}
-              <text className={styles.text} style={{fontSize: "15px", 
-                                                    textOverflow: "ellipsis", 
-                                                    width: "250px",
-                                                    textAlign: "center",}}>
-                {Spicetify.Player.data.item.album.name}
-              </text>
-            </div>
+                {/* Track album */}
+                <text className={styles.text} style={{fontSize: "15px", 
+                                                      textOverflow: "ellipsis", 
+                                                      width: "250px",
+                                                      textAlign: "center",}}>
+                  {Spicetify.Player.data.item.album.name}
+                </text>
+              </div>
+            : <></>}
           </div>
           <div style={{display: "flex", flexDirection: "row"}}>
             <DynamicRecommendations recTargetProp={this.state.recTarget}></DynamicRecommendations>

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -5,7 +5,7 @@ import { AudioFeaturesResponse } from "../types/spotify-web-api";
 import DynamicRecommendations from "./DynamicRecommendations";
 import SongMetric from "./SongMetric";
 import { SongMetricData } from "../types/enhancify";
-import { getSongMetrics } from "../services/common";
+import { getSongMetrics } from "../services/enhancifyInternalService";
 
 class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesResponse | {}, 
                                               songURI: string, 

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -4,8 +4,6 @@ import getAudioFeatures from "../services/nowPlayingService";
 import { AudioFeaturesResponse } from "../types/spotify-web-api";
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
-import getRecommendations from "../services/dynamicRecommendationsService";
-import { GetRecommendationsInput, GetRecommendationsResponse } from "../types/spotify-web-api.d";
 import DynamicRecommendations from "./DynamicRecommendations";
 
 class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesResponse | {}, 
@@ -16,9 +14,6 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
     audioFeatures: {},  // Features of the currently playing song (name, artist, stats)
     songURI: "",        // URI of the currently playing song
     recTarget: "songs", // Recommendations based on either songs or artist
-    // songPlayerInfo: {},
-    // queue: Spicetify.LocalStorage.get("queue")?.split(',') || new Array<string>,
-    // recommendations: {},
   }
 
   componentDidMount = () => {
@@ -232,7 +227,6 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
               {"Settings"}</div>
           <div className={styles.settingContainer}>
             <span className={styles.settingLabel}>{"Show recommendations by: "}</span>
-            {/* <span style={{flexGrow: "1"}}></span> */}
             <button onClick={this.changeRecTarget} className={styles.recommendationTarget}
                     disabled={false} style={{marginLeft: "10px", marginTop: "0px"}}> 
               {this.state.recTarget} 

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -2,8 +2,6 @@ import styles from "../css/app.module.scss";
 import React from "react";
 import getAudioFeatures from "../services/nowPlayingService";
 import { AudioFeaturesResponse } from "../types/spotify-web-api";
-import { CircularProgressbar } from 'react-circular-progressbar';
-import 'react-circular-progressbar/dist/styles.css';
 import DynamicRecommendations from "./DynamicRecommendations";
 import SongMetric from "./SongMetric";
 import { SongMetricData } from "../types/enhancify";
@@ -151,10 +149,12 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
           {"Song Statistics"}
         </div>
         <div className={styles.statsBlock}>
+
           {/* Stats block data */}
           {this.state.songMetrics.map((songMetric: SongMetricData, i) => {
             return <SongMetric title={songMetric.title} floatValue={songMetric.floatValue} label={songMetric.label} progressBar={songMetric.progressBar} />;
           })}
+
         </div>
         <div>
           <div className={styles.recommendationsLabel} style={{marginLeft: "20px",

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -6,15 +6,21 @@ import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import DynamicRecommendations from "./DynamicRecommendations";
 import SongMetric from "./SongMetric";
+import { SongMetricData } from "../types/enhancify";
+import { getSongMetrics } from "../services/common";
 
 class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesResponse | {}, 
                                               songURI: string, 
-                                              recTarget: string}> {
+                                              recTarget: string,
+                                              songMetrics: SongMetricData[],
+                                              metricsToDisplay: string[]}> {
   
   state = {
     audioFeatures: {},  // Features of the currently playing song (name, artist, stats)
     songURI: "",        // URI of the currently playing song
     recTarget: "songs", // Recommendations based on either songs or artist
+    songMetrics: [],
+    metricsToDisplay: [],
   }
 
   componentDidMount = () => {
@@ -36,11 +42,21 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
       const currentAudioFeatures = await getAudioFeatures(this.state.songURI || "");
       this.setState({
         audioFeatures: currentAudioFeatures,
-      });
+      }, this.setSongMetrics);
     }
 
     // Make the API call
     apiCall();
+  }
+
+  setSongMetrics = () => {
+    this.setState({
+      metricsToDisplay: ["Danceability", "Energy", "Acousticness", "Loudness", "Key", "Tempo"]
+    }, () => {
+      this.setState({
+        songMetrics: getSongMetrics((this.state.audioFeatures as AudioFeaturesResponse), this.state.metricsToDisplay)
+      });
+    })
   }
 
   // Change the recommendation target
@@ -135,23 +151,27 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
           {"Song Statistics"}
         </div>
         <div className={styles.statsBlock}>
+          {this.state.songMetrics.map((songMetric: SongMetricData, i) => {
+            return <SongMetric title={songMetric.title} floatValue={songMetric.floatValue} label={songMetric.label} progressBar={songMetric.progressBar} />;
+          })}
+
           {/* Statistic #1 */}
-          <SongMetric title="Danceability" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["danceability"]} label="" progressBar={true} />
+          {/* <SongMetric title="Danceability" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["danceability"]} label="" progressBar={true} /> */}
 
           {/* Statistic #2 */}
-          <SongMetric title="Energy" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["energy"]} label="" progressBar={true} />
+          {/* <SongMetric title="Energy" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["energy"]} label="" progressBar={true} /> */}
 
           {/* Statistic #3 */}
-          <SongMetric title="Acousticness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["acousticness"]} label="" progressBar={true} />
+          {/* <SongMetric title="Acousticness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["acousticness"]} label="" progressBar={true} /> */}
 
           {/* Statistic #4 */}
-          <SongMetric title="Loudness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["loudness"]} label="dB" progressBar={false} />
+          {/* <SongMetric title="Loudness" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["loudness"]} label="dB" progressBar={false} /> */}
 
           {/* Statistic #5 */}
-          <SongMetric title="Key" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["key"]} label="" progressBar={false} />
+          {/* <SongMetric title="Key" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["key"]} label="" progressBar={false} /> */}
 
           {/* Statistic #6 */}
-          <SongMetric title="Tempo" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["tempo"]} label="" progressBar={false} />
+          {/* <SongMetric title="Tempo" floatValue={(this.state.audioFeatures as AudioFeaturesResponse)["tempo"]} label="" progressBar={false} /> */}
         </div>
         <div>
           <div className={styles.recommendationsLabel} style={{marginLeft: "20px",

--- a/src/components/RecommendedTrack.tsx
+++ b/src/components/RecommendedTrack.tsx
@@ -1,5 +1,5 @@
 import styles from "../css/app.module.scss";
-import React, { ReactNode } from "react"; 
+import React from "react"; 
 
 class RecommendedTrack extends React.Component<{songCover: string, 
                                                 songName: string, 

--- a/src/components/SongMetric.tsx
+++ b/src/components/SongMetric.tsx
@@ -1,0 +1,38 @@
+import styles from "../css/app.module.scss";
+import React from "react"; 
+import { CircularProgressbar } from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
+
+class SongMetric extends React.Component<{floatValue: string, 
+                                                title: string, 
+                                                progressBar: boolean, 
+                                                label: string}, 
+                                                {}>  {
+    
+    render() {
+        return (
+          <div className={styles.statContainer}>
+            <div className={styles.statTextContainer}>
+              <div className={styles.text} style={{fontSize: "23px", color: "rgb(200,200,200)", fontWeight: "600"}}>
+                {this.props.title}
+              </div>
+              <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
+                {Math.round(parseFloat(this.props.floatValue) * (this.props.progressBar ? 100 : 1))}
+                { this.props.label != "" ?
+                  <span className={styles.text} style={{fontSize: "25px", color: "white", fontWeight: "550", marginLeft: "5px"}}>
+                    {this.props.label}
+                  </span> : <></> }
+              </div>
+            </div>
+            <div className={styles.graphicContainer}>
+              { this.props.progressBar ? 
+                <CircularProgressbar styles={{path: {stroke: "white"}, trail: {stroke: "rgb(80,80,80)"}}} 
+                                    value={parseFloat(this.props.floatValue)} maxValue={1}>
+                </CircularProgressbar> : <></> }
+            </div>
+          </div>
+        );
+    }
+}
+
+export default SongMetric;

--- a/src/components/SongMetric.tsx
+++ b/src/components/SongMetric.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 
+// Component for each individual song metric data block
 class SongMetric extends React.Component<{floatValue: string, 
                                                 title: string, 
                                                 progressBar: boolean, 
@@ -18,6 +19,8 @@ class SongMetric extends React.Component<{floatValue: string,
               </div>
               <div className={styles.text} style={{fontSize: "48px", color: "white", fontWeight: "500"}}>
                 {Math.round(parseFloat(this.props.floatValue) * (this.props.progressBar ? 100 : 1))}
+
+                {/* Label represents the unit (something like dB, bpm, etc.) */}
                 { this.props.label != "" ?
                   <span className={styles.text} style={{fontSize: "25px", color: "white", fontWeight: "550", marginLeft: "5px"}}>
                     {this.props.label}

--- a/src/services/common.tsx
+++ b/src/services/common.tsx
@@ -1,5 +1,66 @@
+import { Labels, MetricFeatures, SongMetricData } from "../types/enhancify";
+import { AudioFeaturesResponse } from "../types/spotify-web-api";
+
 function getID(uri: string): string {
   return uri.split(":")[2];
+}
+
+export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDisplay: string[]): SongMetricData[] {
+  let res: SongMetricData[] = [];
+  for (const metric of metricsToDisplay) {
+    res.push({
+      title: metric,
+      floatValue: audioFeatures[metric.toLowerCase() as keyof AudioFeaturesResponse],
+      label: metric in metricFeatures.label ? metricFeatures.label[metric as keyof Labels] : "",
+      progressBar: metricFeatures.progressbar.has(metric),
+    });
+  }
+  return res;
+    // return [
+    //   {
+    //     title: "Danceability",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["danceability"],
+    //     label: "",
+    //     progressBar: true
+    //   },
+    //   {
+    //     title: "Energy",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["energy"],
+    //     label: "",
+    //     progressBar: true
+    //   },
+    //   {
+    //     title: "Acousticness",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["acousticness"],
+    //     label: "",
+    //     progressBar: true
+    //   },
+    //   {
+    //     title: "Loudness",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["loudness"],
+    //     label: "dB",
+    //     progressBar: false
+    //   },
+    //   {
+    //     title: "Key",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["key"],
+    //     label: "",
+    //     progressBar: false
+    //   },
+    //   {
+    //     title: "Tempo",
+    //     floatValue: (audioFeatures as AudioFeaturesResponse)["tempo"],
+    //     label: "",
+    //     progressBar: false
+    //   },
+    // ];
+}
+
+const metricFeatures: MetricFeatures = {
+  progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
+  label: {
+    Loudness: "dB"
+  }
 }
 
 export default getID;

--- a/src/services/common.tsx
+++ b/src/services/common.tsx
@@ -1,29 +1,5 @@
-import { Labels, MetricFeatures, SongMetricData } from "../types/enhancify";
-import { AudioFeaturesResponse } from "../types/spotify-web-api";
-
 function getID(uri: string): string {
   return uri.split(":")[2];
-}
-
-export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDisplay: string[]): SongMetricData[] {
-  let res: SongMetricData[] = [];
-  for (const metric of metricsToDisplay) {
-    res.push({
-      title: metric,
-      floatValue: audioFeatures[metric.toLowerCase() as keyof AudioFeaturesResponse],
-      label: metric in metricFeatures.label ? metricFeatures.label[metric as keyof Labels] : "",
-      progressBar: metricFeatures.progressbar.has(metric),
-    });
-  }
-  return res;
-}
-
-const metricFeatures: MetricFeatures = {
-  progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
-  label: {
-    Loudness: "dB",
-    Tempo: "bpm",
-  }
 }
 
 export default getID;

--- a/src/services/common.tsx
+++ b/src/services/common.tsx
@@ -16,50 +16,13 @@ export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDi
     });
   }
   return res;
-    // return [
-    //   {
-    //     title: "Danceability",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["danceability"],
-    //     label: "",
-    //     progressBar: true
-    //   },
-    //   {
-    //     title: "Energy",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["energy"],
-    //     label: "",
-    //     progressBar: true
-    //   },
-    //   {
-    //     title: "Acousticness",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["acousticness"],
-    //     label: "",
-    //     progressBar: true
-    //   },
-    //   {
-    //     title: "Loudness",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["loudness"],
-    //     label: "dB",
-    //     progressBar: false
-    //   },
-    //   {
-    //     title: "Key",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["key"],
-    //     label: "",
-    //     progressBar: false
-    //   },
-    //   {
-    //     title: "Tempo",
-    //     floatValue: (audioFeatures as AudioFeaturesResponse)["tempo"],
-    //     label: "",
-    //     progressBar: false
-    //   },
-    // ];
 }
 
 const metricFeatures: MetricFeatures = {
   progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
   label: {
-    Loudness: "dB"
+    Loudness: "dB",
+    Tempo: "bpm",
   }
 }
 

--- a/src/services/enhancifyInternalService.tsx
+++ b/src/services/enhancifyInternalService.tsx
@@ -1,0 +1,23 @@
+import { Labels, MetricFeatures, SongMetricData } from "../types/enhancify";
+import { AudioFeaturesResponse } from "../types/spotify-web-api";
+
+export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDisplay: string[]): SongMetricData[] {
+  let res: SongMetricData[] = [];
+  for (const metric of metricsToDisplay) {
+    res.push({
+      title: metric,
+      floatValue: audioFeatures[metric.toLowerCase() as keyof AudioFeaturesResponse],
+      label: metric in metricFeatures.label ? metricFeatures.label[metric as keyof Labels] : "",
+      progressBar: metricFeatures.progressbar.has(metric),
+    });
+  }
+  return res;
+}
+
+const metricFeatures: MetricFeatures = {
+  progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
+  label: {
+    Loudness: "dB",
+    Tempo: "bpm",
+  }
+};

--- a/src/services/enhancifyInternalService.tsx
+++ b/src/services/enhancifyInternalService.tsx
@@ -16,6 +16,7 @@ export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDi
 }
 
 // Object that represents which metrics require a progress bar and which metrics require a specific label
+// TODO: Add information for other metrics that we can show the user
 const metricFeatures: MetricFeatures = {
   progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
   label: {

--- a/src/services/enhancifyInternalService.tsx
+++ b/src/services/enhancifyInternalService.tsx
@@ -1,6 +1,7 @@
 import { Labels, MetricFeatures, SongMetricData } from "../types/enhancify";
 import { AudioFeaturesResponse } from "../types/spotify-web-api";
 
+// Dynamically fills in the song metric information based on the specific metrics that the user wants to display
 export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDisplay: string[]): SongMetricData[] {
   let res: SongMetricData[] = [];
   for (const metric of metricsToDisplay) {
@@ -14,6 +15,7 @@ export function getSongMetrics(audioFeatures: AudioFeaturesResponse, metricsToDi
   return res;
 }
 
+// Object that represents which metrics require a progress bar and which metrics require a specific label
 const metricFeatures: MetricFeatures = {
   progressbar: new Set(["Danceability", "Energy", "Acousticness"]),
   label: {

--- a/src/types/enhancify.d.ts
+++ b/src/types/enhancify.d.ts
@@ -7,6 +7,7 @@ export type SongMetricData = {
 
 export type Labels = {
   Loudness: string
+  Tempo: string
 }
 
 export type MetricFeatures = {

--- a/src/types/enhancify.d.ts
+++ b/src/types/enhancify.d.ts
@@ -1,0 +1,15 @@
+export type SongMetricData = {
+  title: string,
+  floatValue: string,
+  label: string,
+  progressBar: boolean
+};
+
+export type Labels = {
+  Loudness: string
+}
+
+export type MetricFeatures = {
+  progressbar: Set<string>,
+  label: Labels
+};


### PR DESCRIPTION
This PR does some code cleanup/refactoring and allows us to dynamically show song metrics. It should now be very easy to eventually implement allowing the user to choose what metrics they want to see.

I also believe I fixed the bug that occurs when no track is playing. In the HTML we were using `Spicetify.Player.data` without checking that it exists first. I don't have any way to test this to make sure it fixes the bug, but I'm pretty certain that it should.