### PR TITLE
Fix for Playlist Manager UI Injection 

### DIFF
--- a/src/extensions/playlistExtension.tsx
+++ b/src/extensions/playlistExtension.tsx
@@ -297,7 +297,7 @@ const initPlaylistPageLogic = () => {
             trackOrder: prefixedTrackOrder,
         };
         localStorage.setItem(`preset-${name}-${playlistID}`, JSON.stringify(preset));
-        Spicetify.showNotification(`Preset '${name}' saved.`);
+        Spicetify.showNotification(`Preset saved.`);
     };
 
     const loadPreset = async (name: string, playlistID: string) => {

--- a/src/extensions/playlistExtension.tsx
+++ b/src/extensions/playlistExtension.tsx
@@ -381,3 +381,7 @@ const initPlaylistPageLogic = () => {
 };
 
 initPlaylistPageLogic();
+
+Spicetify.Platform.History.listen(() => {
+    initPlaylistPageLogic();
+});

--- a/src/services/reorderPlaylistService.tsx
+++ b/src/services/reorderPlaylistService.tsx
@@ -22,32 +22,32 @@ export default async function reorderPlaylist(playlistID: string, sortedTrackURI
 }
 
 async function PlaylistAPICall(requestType: string, uri: string, chunk: string[]) {
-  const accessToken = Spicetify.Platform.Session.accessToken;
+    const accessToken = Spicetify.Platform.Session.accessToken;
 
-  let trackURIs = [];
-  if (requestType == "DELETE") {
-      for (const songURI of chunk) {
-          trackURIs.push({
-              uri: songURI
-          });
-      }
-  }
+    let trackURIs = [];
+    if (requestType == "DELETE") {
+        for (const songURI of chunk) {
+            trackURIs.push({
+                uri: songURI
+            });
+        }
+    }
 
-  let response = await fetch(uri, {
-      method: requestType,
-      headers: {
-          Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify(requestType == "POST" ? {
-          uris: chunk
-      } : {
-          tracks: trackURIs
-      }),
-  });
+    let response = await fetch(uri, {
+        method: requestType,
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(requestType == "POST" ? {
+            uris: chunk
+        } : {
+            tracks: trackURIs
+        }),
+    });
 
-  if (response.status == 200) {
-      console.log(requestType, ' playlist API call successful!');
-  } else {
-      console.error('Failed ', requestType, ' playlist API call: ', response.status, response.statusText);
-  }
+    if (response.status == 200) {
+        console.log(requestType, ' playlist API call successful!');
+    } else {
+        console.error('Failed ', requestType, ' playlist API call: ', response.status, response.statusText);
+    }
 }

--- a/src/services/reorderPlaylistService.tsx
+++ b/src/services/reorderPlaylistService.tsx
@@ -4,25 +4,50 @@ export default async function reorderPlaylist(playlistID: string, sortedTrackURI
         return;
     }
 
-    const accessToken = Spicetify.Platform.Session.accessToken;
     const uri = `https://api.spotify.com/v1/playlists/${playlistID}/tracks`;
 
-    // Make the PUT request to reorder the playlist
-    const response = await fetch(uri, {
-        method: 'PUT',
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-            uris: sortedTrackURIs,
-        }),
-    });
-
-    if (response.ok) {
-        console.log('Playlist successfully reordered!');
-        return response.json();
-    } else {
-        console.error('Failed to reorder playlist:', response.status, response.statusText);
+    const chunks = [];
+    const chunkSize = 100;
+    for (let i = 0; i < sortedTrackURIs.length; i += chunkSize) {
+        chunks.push(sortedTrackURIs.slice(i, i + chunkSize));
     }
+
+    for (const chunk of chunks) {
+        // Make DELETE request to delete the tracks that will be pushed again
+        await PlaylistAPICall("DELETE", uri, chunk);
+
+        // Make POST request to add the new order
+        await PlaylistAPICall("POST", uri, chunk);
+    }
+}
+
+async function PlaylistAPICall(requestType: string, uri: string, chunk: string[]) {
+  const accessToken = Spicetify.Platform.Session.accessToken;
+
+  let trackURIs = [];
+  if (requestType == "DELETE") {
+      for (const songURI of chunk) {
+          trackURIs.push({
+              uri: songURI
+          });
+      }
+  }
+
+  let response = await fetch(uri, {
+      method: requestType,
+      headers: {
+          Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(requestType == "POST" ? {
+          uris: chunk
+      } : {
+          tracks: trackURIs
+      }),
+  });
+
+  if (response.status == 200) {
+      console.log(requestType, ' playlist API call successful!');
+  } else {
+      console.error('Failed ', requestType, ' playlist API call: ', response.status, response.statusText);
+  }
 }


### PR DESCRIPTION
UI was not injecting if the user navigated to a non-playlist page and back to a playlist page, the UI wouldn't get injected. But navigating to another playlist page after that would successfully inject the UI.

Fixed all of these issues by adding a permanent platform history listener so that we are always detecting the current page at any point and then applying functionality/logic from there. 

Kept the original call to "initPlaylistPageLogic" to ensure that on load, if the loaded page is a playlist page it will check if it is a playlist page and apply the logic, since the "History" only collects once a user navigates themselves to a page, not on load.l