### PR TITLE
Listening History

### DIFF
--- a/src/components/ListeningHistoryModal.tsx
+++ b/src/components/ListeningHistoryModal.tsx
@@ -38,6 +38,7 @@ class ListeningHistoryModal extends React.Component <{setModalIsOpen: (value: bo
         }
     }
 
+
     async componentDidMount(): Promise<void> {
         let newState = await getRecentlyPlayedTracksMetrics();
         this.setState({
@@ -54,6 +55,33 @@ class ListeningHistoryModal extends React.Component <{setModalIsOpen: (value: bo
                                                                         marginTop:    "10px",
                                                                         }}>
                         {"Listening History"}
+                    </div>
+                    <div style={{fontSize: "large",
+                                 marginLeft: "15px",
+                                 marginTop: "26px"
+                                }}>
+                        {"Week of "}
+                        <span style={{fontWeight: "bolder"}}>
+                            {function() {
+                                let getDateRange = () => {
+                                    let weekStartDate = new Date();              // Date of the first day of the week
+                                    let day = weekStartDate.getDay() || 7;       // Return 7 if day is Sunday
+                            
+                                    // If today is not a Monday, then rewind the
+                                    // date back to Monday
+                                    if (day != 1) {
+                                        weekStartDate.setHours(-24 * (day - 1));
+                                    }
+                            
+                                    // First Monday of the week and the current date
+                                    return weekStartDate;
+                                }
+
+                                let weekStartDate = getDateRange();
+
+                                return `${weekStartDate.getMonth() + 1}/${weekStartDate.getDate()}`;
+                            }()}
+                        </span>
                     </div>
                     <img className={styles.playIcon} style={{marginLeft: "auto"}} 
                         src={"https://img.icons8.com/?size=100&id=6483&format=png&color=FFFFFF"} 

--- a/src/components/ListeningHistoryModal.tsx
+++ b/src/components/ListeningHistoryModal.tsx
@@ -1,0 +1,80 @@
+import styles from "../css/app.module.scss";
+import React from "react";
+import type { HistoricalMetrics } from "../types/enhancify";
+import getRecentlyPlayedTracksMetrics from "./../services/recentlyPlayedService"
+import SongMetric from "./SongMetric";
+
+class ListeningHistoryModal extends React.Component <{setModalIsOpen: (value: boolean) => void}, {metricsValues: HistoricalMetrics | {}}> {
+    state = {
+        metricsValues: {
+            acousticness: {
+                average: 0,
+                count: 0
+            },
+            danceability: {
+                average: 0,
+                count: 0
+            },
+            energy: {
+                average: 0,
+                count: 0
+            },
+            instrumentalness: {
+                average: 0,
+                count: 0
+            },
+            liveness: {
+                average: 0,
+                count: 0
+            },
+            speechiness: {
+                average: 0,
+                count: 0
+            },
+            valence: {
+                average: 0,
+                count: 0
+            },
+        }
+    }
+
+    async componentDidMount(): Promise<void> {
+        let newState = await getRecentlyPlayedTracksMetrics();
+        this.setState({
+            metricsValues: newState,
+        });
+    }
+
+    render() {
+        return (
+            <div className={styles.settingsModalContainer} style={{paddingBottom: "20px", paddingLeft: "40px"}}>
+                <div className={styles.modalHeaderContainer}>
+                    <div className={styles.recommendationsLabel} style={{marginLeft:  "20px",
+                                                                        marginBottom: "0px",
+                                                                        marginTop:    "10px",
+                                                                        }}>
+                        {"Listening History"}
+                    </div>
+                    <img className={styles.playIcon} style={{marginLeft: "auto"}} 
+                        src={"https://img.icons8.com/?size=100&id=6483&format=png&color=FFFFFF"} 
+                        onClick={() => this.props.setModalIsOpen(false)}/>
+                </div>
+                <div className={styles.statsBlock} style={{marginBottom: "40px"}}>
+                    {Object.keys(this.state.metricsValues).map((metric: string) => {
+                        if (this.state.metricsValues[metric as keyof HistoricalMetrics].count) {
+                            return <SongMetric title={metric}
+                                            floatValue={this.state.metricsValues[metric as keyof HistoricalMetrics].average.toString()}
+                                            label={""}
+                                            progressBar={true}
+                                            selectMetric={(metric: string, value: string) => {}}
+                                    ></SongMetric>;
+                        } else {
+                        return <></>;
+                        }
+                    })}
+                </div>
+            </div>);
+    }
+}
+
+export default ListeningHistoryModal;

--- a/src/components/NowPlaying.tsx
+++ b/src/components/NowPlaying.tsx
@@ -8,6 +8,7 @@ import { SelectedMetrics, SongMetricData } from "../types/enhancify";
 import { allMetrics, getSongMetrics } from "../services/enhancifyInternalService";
 import RecommendationsModal from "./RecommendationsModal";
 import SettingsModal from "./SettingsModal";
+import ListeningHistoryModal from "./ListeningHistoryModal";
 import Modal from 'react-modal';
 
 class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesResponse | {}, 
@@ -17,6 +18,7 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
                                               metricsToDisplay: string[],
                                               modalIsOpen: boolean,
                                               settingsModalIsOpen: boolean,
+                                              historyModalIsOpen: boolean,
                                               selectedMetrics: SelectedMetrics}> {
   
   state = {
@@ -29,7 +31,8 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
                           ["Danceability", "Energy", "Acousticness", "Loudness", "Key", "Tempo"] : 
                           [],     // Current metric information types
     modalIsOpen:         false,   // Whether the modal is currently open
-    settingsModalIsOpen: false,   
+    settingsModalIsOpen: false,
+    historyModalIsOpen:  false,   
     selectedMetrics:     JSON.parse(Spicetify.LocalStorage.get("selectedMetrics") || 
                          "{}"), // Metrics that have been selected to be fed into the Spotify recommendations endpoint
   }
@@ -120,6 +123,12 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
     });
   }
 
+  setHistoryModalIsOpen = (value: boolean) => {
+    this.setState({
+      historyModalIsOpen: value,
+    })
+  }
+
   // Select a metric to toggle whether they should be included in the recommendations endpoint request or not
   selectMetric = (metric: string, value: string) => {
     let copy: SelectedMetrics = { ...this.state.selectedMetrics };
@@ -160,6 +169,20 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
       transform: 'translate(-50%, -50%)',
       width:     "50%",
       height:    "600px"
+    },
+  }
+
+  historicalMetricsModalStyles = {
+    overlay: {
+      backgroundColor: "rgba(0, 0, 0, 0.70)",
+    },
+    content: {
+      position:  'absolute',
+      top:       '43%',
+      left:      '47%',
+      transform: 'translate(-50%, -50%)',
+      width:     "70%",
+      height:    "640px"
     },
   }
 
@@ -248,8 +271,15 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
                            marginTop: "auto", 
                            marginBottom: "auto"}} />
           </div>
-          <div className={styles.settingsIconContainer} onClick={() => this.setSettingsModalIsOpen(true)}>
+          <div className={styles.settingsIconContainer} style={{marginRight: "0px"}} onClick={() => this.setSettingsModalIsOpen(true)}>
               <img src={"https://img.icons8.com/?size=100&id=2969&format=png&color=FFFFFF"} 
+                   style={{width: "25px", 
+                           height: "25px", 
+                           marginTop: "auto", 
+                           marginBottom: "auto"}} />
+          </div>
+          <div className={styles.settingsIconContainer} onClick={() => this.setHistoryModalIsOpen(true)}>
+              <img src={"https://img.icons8.com/?size=100&id=8309&format=png&color=FFFFFF"} 
                    style={{width: "25px", 
                            height: "25px", 
                            marginTop: "auto", 
@@ -279,6 +309,9 @@ class NowPlaying extends React.Component<{}, {audioFeatures: AudioFeaturesRespon
         <Modal className={styles.modal} isOpen={this.state.settingsModalIsOpen} onRequestClose={() => this.setSettingsModalIsOpen(false)} style={this.modalStyles}>
             <SettingsModal changeRecTarget={this.changeRecTarget} toggleMetric={this.toggleMetric} recTarget={this.state.recTarget} metricsToDisplay={this.state.metricsToDisplay} 
                             setModalIsOpen={this.setSettingsModalIsOpen}/>
+        </Modal>
+        <Modal className={styles.modal} isOpen={this.state.historyModalIsOpen} onRequestClose={() => this.setHistoryModalIsOpen(false)} style={this.historicalMetricsModalStyles}>
+          <ListeningHistoryModal setModalIsOpen={this.setHistoryModalIsOpen}></ListeningHistoryModal>
         </Modal>
       </>
     );

--- a/src/components/SongMetric.tsx
+++ b/src/components/SongMetric.tsx
@@ -8,8 +8,8 @@ class SongMetric extends React.Component<{floatValue: string,
                                                 title: string, 
                                                 progressBar: boolean, 
                                                 label: string,
-                                                selectMetric: (metric: string, value: string) => void
-                                                isMetricSelected: boolean}, 
+                                                selectMetric: (metric: string, value: string) => void 
+                                                isMetricSelected?: boolean}, 
                                                 {}>  {
     
     render() {

--- a/src/services/recentlyPlayedService.tsx
+++ b/src/services/recentlyPlayedService.tsx
@@ -1,0 +1,102 @@
+import type { GetRecentlyPlayedTracksResponse, GetRecentlyPlayedTracksInput, AudioFeaturesResponse } from "../types/spotify-web-api";
+import getMultiTrackAudioFeatures from "./multiTrackAudioFeaturesService";
+import type { HistoricalMetrics } from "../types/enhancify";
+
+async function getRecentlyPlayedTracksMetrics(apiOptions: GetRecentlyPlayedTracksInput) : Promise<HistoricalMetrics | {}> {
+    let url = "https://api.spotify.com/v1/me/player/recently-played";
+
+    // Extract the query parameters from the API options input
+    // to create a request string
+    let queryParams: string[] = [];
+    for (const [key, value] of Object.entries(apiOptions.data)) {
+        if (!value) {
+            continue;
+        }
+        queryParams.push(key + "=" + value);
+    }
+    url += queryParams.join("&");
+
+    var accessToken = Spicetify.Platform.Session.accessToken;
+
+    // Make the API request to get the recently
+    // played songs
+    let RecentlyPlayedTracksResponse = await fetch(url, 
+        {
+            headers: {
+                Authorization: "Bearer " + accessToken,
+            },
+
+        }
+    );
+    
+    // If the respone was not successfully retrieved,
+    // then return an empty object
+    if (RecentlyPlayedTracksResponse.status != 200) {
+        return {};
+    }
+
+    // Get the musical characteristics of each song
+    // Get all the song ids
+    let songIDs: string[] = [];
+    let RecentlyPlayedTracksResponseJSON = await RecentlyPlayedTracksResponse.json();
+    for (let item of RecentlyPlayedTracksResponseJSON.items) {
+        songIDs.push(item.track.id);
+    }
+    let audioFeatures = await getMultiTrackAudioFeatures(songIDs);
+
+    // Process the audio features
+    let relevantMetrics = ["acousticness", "danceability", "energy", "instrumentalness",
+                           "liveness", "speechiness", "valence"];
+    let metricsData: { [metric: string]: {total: number, count: number} } = {};
+    for (let metric of relevantMetrics) {
+        metricsData[metric] = {total: 0, count: 0};
+    }
+    for (let audioFeature of audioFeatures) {
+        for (let feature of Object.keys(audioFeature)) {
+            if (feature in relevantMetrics) {
+                if (audioFeature[feature as keyof AudioFeaturesResponse]) {
+                    metricsData[feature].total += parseInt(audioFeature[feature as keyof AudioFeaturesResponse]);
+                    metricsData[feature].count += 1;
+                }
+            }
+        }
+    }
+
+    // Average out the song metrics
+    let result: HistoricalMetrics = {
+        acousticness: {
+            average: 0,
+            count: 0
+        },
+        danceability: {
+            average: 0,
+            count: 0
+        },
+        energy: {
+            average: 0,
+            count: 0
+        },
+        instrumentalness: {
+            average: 0,
+            count: 0
+        },
+        liveness: {
+            average: 0,
+            count: 0
+        },
+        speechiness: {
+            average: 0,
+            count: 0
+        },
+        valence: {
+            average: 0,
+            count: 0
+        }
+    };
+    for (let metric in Object.keys(metricsData)) {
+        result[metric as keyof HistoricalMetrics].average = metricsData[metric].total / metricsData[metric].count;
+        result[metric as keyof HistoricalMetrics].count = metricsData[metric].count;
+    }
+
+    return result;
+}

--- a/src/services/recentlyPlayedService.tsx
+++ b/src/services/recentlyPlayedService.tsx
@@ -10,8 +10,11 @@ async function getRecentlyPlayedTracksMetrics() : Promise<HistoricalMetrics | {}
                         after: "",
                      };
     // Get the date of the first day of the week
-    let today = new Date();
-    let day = today.getDay() || 7;
+    let today = new Date();         
+    let day = today.getDay() || 7; // Return 7 if day is Sunday
+
+    // If today is not a Monday, then rewind the
+    // date back to the previous Monday
     if (day != 1) {
         today.setHours(-24 * (day - 1));
     }

--- a/src/types/enhancify.d.ts
+++ b/src/types/enhancify.d.ts
@@ -21,3 +21,34 @@ export type MetricFeatures = {
 export type SelectedMetrics = {
   [metric: string]: string
 };
+
+export type HistoricalMetrics = {
+  acousticness: {
+    average: number, 
+    count: number
+  }, 
+  danceability: {
+    average: number, 
+    count: number
+  }, 
+  energy: {
+    average: number, 
+    count: number
+  }, 
+  instrumentalness: {
+    average: number, 
+    count: number
+  }, 
+  liveness: {
+    average: number, 
+    count: number
+  }, 
+  speechiness: {
+    average: number, 
+    count: number
+  }, 
+  valence: {
+    average: number, 
+    count: number
+  }
+}

--- a/src/types/spotify-web-api.d.ts
+++ b/src/types/spotify-web-api.d.ts
@@ -160,3 +160,111 @@ export type GetRecommendationsResponse = {
       is_local: boolean
     }[]
 };
+
+export class GetRecentlyPlayedTracks {
+  data = new RecentlyPlayedTracks();
+}
+
+export class RecentlyPlayedTracks {
+  limit = "50";
+  after = "";
+}
+
+export type GetRecentlyPlayedTracksResponse = {
+  href: string,
+  limit: number,
+  next: string,
+  cursors: {
+    after: string,
+    before: string
+  },
+  total: number,
+  items: 
+  {
+    track: 
+    {
+      album: {
+        album_type: string,
+        total_tracks: number,
+        available_markets: string[],
+        external_urls: {
+          spotify: string
+        },
+        href: string,
+        id: string,
+        images:
+          {
+            url: string,
+            height: number,
+            width: number,
+          }[],
+        name: string,
+        release_date: string,
+        release_date_precision: string,
+        restrictions: {
+          reason: string,
+        },
+        type: string,
+        uri: string,
+        artists:
+          {
+            external_urls: {
+              spotify: string
+            },
+            href: string,
+            id: string,
+            name: string,
+            type: string,
+            uri: string
+          }[]
+      },
+      artists:
+        {
+          external_urls: {
+            spotify: string
+          },
+          href: string,
+          id: string,
+          name: string,
+          type: string,
+          uri: string
+        }[],
+      available_markets:
+        string[],
+      disc_number: number,
+      duration_ms: number,
+      explicit: boolean,
+      external_ids: {
+        isrc: string,
+        ean: string,
+        upc: string
+      },
+      external_urls: {
+        spotify: string
+      },
+      href: string,
+      id: string,
+      is_playable: boolean,
+      linked_from: {},
+      restrictions: {
+        reason: string
+      },
+      name: string,
+      popularity: number,
+      preview_url: string,
+      track_number: number,
+      type: string,
+      uri: string,
+      is_local: boolean
+    },
+    played_at: string,
+    context: {
+      type: string,
+      href: string,
+      external_urls: {
+        spotify: string
+      },
+      uri: string
+    }
+  }[]
+}

--- a/src/types/spotify-web-api.d.ts
+++ b/src/types/spotify-web-api.d.ts
@@ -161,7 +161,7 @@ export type GetRecommendationsResponse = {
     }[]
 };
 
-export class GetRecentlyPlayedTracks {
+export class GetRecentlyPlayedTracksInput {
   data = new RecentlyPlayedTracks();
 }
 


### PR DESCRIPTION
This PR adds listening history functionality. Each week, the user can log in to the Spotify desktop app to review the average values of the musical characteristics of the songs they listened to in that week. To view the statistics, the user should navigate to the "now playing" page. From that page, the user should click on the bar graph icon in the middle-right corner of the screen. Upon clicking the icon, a pop-up will appear that will contain the statistics.